### PR TITLE
[misc] Seperated user's state of modules

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -58,7 +58,7 @@ func GetConfJSON(module string) []byte {
 func SaveConfig(module string, data []byte) error {
 	profile := getProfile(data)
 	err := ConfSaveFunc[module](data, profile)
-	if profile == setup.ModulesStatus.Profile {
+	if profile == setup.UserModuleState.Profile {
 		return err
 	}
 	for _, function := range ConfSaveFunc {
@@ -67,7 +67,7 @@ func SaveConfig(module string, data []byte) error {
 			return err
 		}
 	}
-	setup.ModulesStatus.Profile = profile
+	setup.UserModuleState.Profile = profile
 	return nil
 }
 
@@ -81,6 +81,22 @@ func getProfile(data []byte) string {
 
 //ChangeModuleStatus sends the signal to main function about the changing the status of module
 func ChangeModuleStatus(module string, status bool) {
+	switch module {
+	case "live":
+		setup.UserModuleState.Live = status
+	case "target":
+		setup.UserModuleState.Target = status
+	case "disk":
+		setup.UserModuleState.Disk = status
+	case "inode":
+		setup.UserModuleState.Disk = status
+	case "ram":
+		setup.UserModuleState.RAM = status
+	case "cpu":
+		setup.UserModuleState.CPU = status
+	default:
+		return
+	}
 	utils.SendModuleStatus(module, status)
 }
 
@@ -88,17 +104,17 @@ func ChangeModuleStatus(module string, status bool) {
 func ModuleStatus(module string) bool {
 	switch module {
 	case "live":
-		return setup.ModulesStatus.Live
+		return setup.InternalModuleState.Live
 	case "target":
-		return setup.ModulesStatus.Target
+		return setup.InternalModuleState.Target
 	case "disk":
-		return setup.ModulesStatus.Disk
+		return setup.InternalModuleState.Disk
 	case "inode":
-		return setup.ModulesStatus.Disk
+		return setup.InternalModuleState.Disk
 	case "ram":
-		return setup.ModulesStatus.RAM
+		return setup.InternalModuleState.RAM
 	case "cpu":
-		return setup.ModulesStatus.CPU
+		return setup.InternalModuleState.CPU
 	default:
 		return false
 	}

--- a/cli/action.go
+++ b/cli/action.go
@@ -82,13 +82,13 @@ func status(argument []string) error {
 
 func liveShortStatus() {
 	fmt.Printf("%-35s", "Internet Connectivity (live)")
-	moduleWorkingStatus(setup.ModulesStatus.Live, api.LiveStatus().Normal)
+	moduleWorkingStatus(setup.InternalModuleState.Live, api.LiveStatus().Normal)
 }
 
 func liveDetailStatus() {
 	printHeading("Status of internet connectivity (live) module")
 	fmt.Printf("%-35s", "Internet Connectivity (live) :\t")
-	if setup.ModulesStatus.Live {
+	if setup.InternalModuleState.Live {
 		moduleStatus := api.LiveStatus()
 		if moduleStatus.Normal {
 			color.Green("On")
@@ -112,13 +112,13 @@ func diskShortStatus() {
 			break
 		}
 	}
-	moduleWorkingStatus(setup.ModulesStatus.Disk, normal)
+	moduleWorkingStatus(setup.InternalModuleState.Disk, normal)
 }
 
 func diskDetailStatus() {
 	printHeading("Status of disk module")
 	diskShortStatus()
-	if setup.ModulesStatus.Disk {
+	if setup.InternalModuleState.Disk {
 		printDiskTable()
 		fmt.Println("\n")
 		printInodeTable()
@@ -130,7 +130,7 @@ func printDiskTable() {
 	printLine()
 	color.New(color.FgWhite, color.Bold, color.Underline).Printf("| %-30s | %-15s | %-15s |  %%  |\n",
 		"Filesystem", "Free Blocks", "Total Blocks")
-	if setup.ModulesStatus.Disk {
+	if setup.InternalModuleState.Disk {
 		for key, value := range api.DiskStatus() {
 			colorFunc := color.New(color.FgWhite)
 			if value.Status.Space != 1 {
@@ -149,7 +149,7 @@ func printInodeTable() {
 	printLine()
 	color.New(color.FgWhite, color.Bold, color.Underline).Printf("| %-30s | %-15s | %-15s |  %%  |\n",
 		"Filesystem", "Free Inodes", "Total Inodes")
-	if setup.ModulesStatus.Disk {
+	if setup.InternalModuleState.Disk {
 		for key, value := range api.DiskStatus() {
 			colorFunc := color.New(color.FgWhite)
 			if value.Status.Inode != 1 {
@@ -173,13 +173,13 @@ func percent(value int, total int) int {
 
 func cpuShortStatus() {
 	fmt.Printf("%-35s", "CPU (cpu)")
-	moduleWorkingStatus(setup.ModulesStatus.CPU, api.CPUStatus().Status.Normal)
+	moduleWorkingStatus(setup.InternalModuleState.CPU, api.CPUStatus().Status.Normal)
 }
 
 func cpuDetailStatus() {
 	printHeading("Status of CPU module")
 	cpuShortStatus()
-	if setup.ModulesStatus.CPU {
+	if setup.InternalModuleState.CPU {
 		moduleStatus := api.CPUStatus()
 		colorFunc := color.New(color.FgWhite)
 		if moduleStatus.Status.Normal == false {
@@ -191,13 +191,13 @@ func cpuDetailStatus() {
 
 func ramShortStatus() {
 	fmt.Printf("%-35s", "RAM (ram)")
-	moduleWorkingStatus(setup.ModulesStatus.RAM, api.RAMStatus().Status.Normal)
+	moduleWorkingStatus(setup.InternalModuleState.RAM, api.RAMStatus().Status.Normal)
 }
 
 func ramDetailStatus() {
 	printHeading("Status of RAM module")
 	ramShortStatus()
-	if setup.ModulesStatus.RAM {
+	if setup.InternalModuleState.RAM {
 		moduleStatus := api.RAMStatus()
 		colorFunc := color.New(color.FgWhite)
 		if moduleStatus.Status.Normal == false {
@@ -206,7 +206,7 @@ func ramDetailStatus() {
 		colorFunc.Printf("RAM usage is %d%%\n", percent(moduleStatus.Stats.FreePhysical,
 			moduleStatus.Consts.TotalPhysical))
 
-		colorFunc.Printf("Virtual Memory usage is %d%%\n", percent(moduleStatus.Stats.FreeVirtual,
+		colorFunc.Printf("Virtual Memory usage is %d%%\n", percent(moduleStatus.Stats.FreeSwap,
 			moduleStatus.Consts.TotalVirtual))
 	}
 }
@@ -223,13 +223,13 @@ func targetShortStatus() {
 		}
 	}
 
-	moduleWorkingStatus(setup.ModulesStatus.Target, normal)
+	moduleWorkingStatus(setup.InternalModuleState.Target, normal)
 }
 
 func targetDetailStatus() {
 	color.Cyan("Detailed status of all the OWTF's target")
 	targetShortStatus()
-	if setup.ModulesStatus.Target {
+	if setup.InternalModuleState.Target {
 		for key, value := range api.TargetStatus() {
 			fmt.Printf("%-45s :\t", key)
 			if value.Scanned {
@@ -264,7 +264,7 @@ func moduleWorkingStatus(status bool, workingStatus bool) {
 
 func toggleModule(module string, state bool) error {
 	if doesModuleExists(module) {
-		utils.SendModuleStatus(module, state)
+		api.ChangeModuleStatus(module, state)
 		return nil
 	} else {
 		return errors.New("Specified module not found, allowed modules " + color.New(color.FgCyan).SprintFunc()(utils.Modules))

--- a/cpu/db.go
+++ b/cpu/db.go
@@ -12,7 +12,7 @@ import (
 func LoadConfig() *Config {
 	var conf = new(Config)
 	err := setup.Database.QueryRow("SELECT * FROM CPU WHERE profile=?",
-		setup.ModulesStatus.Profile).Scan(&conf.Profile, &conf.CPUWarningLimit,
+		setup.UserModuleState.Profile).Scan(&conf.Profile, &conf.CPUWarningLimit,
 		&conf.RecheckThreshold)
 	if err != nil {
 		utils.ModuleError(logFile, "Error while quering from databse", err.Error())

--- a/cpu/run.go
+++ b/cpu/run.go
@@ -94,6 +94,6 @@ func GetStatusJSON() []byte {
 func Init() {
 	conf = LoadConfig()
 	if conf == nil {
-		utils.CheckConf(logFile, setup.MainLogFile, "cpu", &setup.ModulesStatus.Profile, setup.CPU)
+		utils.CheckConf(logFile, setup.MainLogFile, "cpu", &setup.UserModuleState.Profile, setup.CPU)
 	}
 }

--- a/disk/db.go
+++ b/disk/db.go
@@ -12,7 +12,7 @@ import (
 func LoadConfig() *Config {
 	var conf = new(Config)
 	err := setup.Database.QueryRow("SELECT * FROM Disk WHERE profile=?",
-		setup.ModulesStatus.Profile).Scan(&conf.Profile, &conf.SpaceWarningLimit,
+		setup.UserModuleState.Profile).Scan(&conf.Profile, &conf.SpaceWarningLimit,
 		&conf.SpaceDangerLimit, &conf.InodeWarningLimit, &conf.InodeDangerLimit,
 		&conf.RecheckThreshold, &conf.Disks)
 	if err != nil {

--- a/disk/run.go
+++ b/disk/run.go
@@ -134,6 +134,6 @@ func GetConfJSON() []byte {
 func Init() {
 	conf = LoadConfig()
 	if conf == nil {
-		utils.CheckConf(logFile, setup.MainLogFile, "disk", &setup.ModulesStatus.Profile, setup.Disk)
+		utils.CheckConf(logFile, setup.MainLogFile, "disk", &setup.UserModuleState.Profile, setup.Disk)
 	}
 }

--- a/healthmon.go
+++ b/healthmon.go
@@ -115,27 +115,27 @@ func controlModuleHelper(run bool, moduleStatus *bool, moduleName string,
 }
 
 func runModules(chans [5]chan bool, wg *sync.WaitGroup) {
-	if setup.InternalModuleState.Live {
+	if setup.UserModuleState.Live {
 		wg.Add(1)
 		utils.ModuleLogs(setup.MainLogFile, "Started live module")
 		go live.Live(chans[0], wg)
 	}
-	if setup.InternalModuleState.Target {
+	if setup.UserModuleState.Target {
 		wg.Add(1)
 		utils.ModuleLogs(setup.MainLogFile, "Started target module")
 		go target.Target(chans[1], wg)
 	}
-	if setup.InternalModuleState.Disk {
+	if setup.UserModuleState.Disk {
 		wg.Add(1)
 		utils.ModuleLogs(setup.MainLogFile, "Started disk module")
 		go disk.Disk(chans[2], wg)
 	}
-	if setup.InternalModuleState.RAM {
+	if setup.UserModuleState.RAM {
 		wg.Add(1)
 		utils.ModuleLogs(setup.MainLogFile, "Started ram module")
 		go ram.RAM(chans[3], wg)
 	}
-	if setup.InternalModuleState.CPU {
+	if setup.UserModuleState.CPU {
 		wg.Add(1)
 		utils.ModuleLogs(setup.MainLogFile, "Started cpu module")
 		go cpu.CPU(chans[4], wg)

--- a/healthmon.go
+++ b/healthmon.go
@@ -81,20 +81,20 @@ func controlModule(chans [5]chan bool, wg *sync.WaitGroup) {
 		data := <-utils.ControlChan
 		switch data.Module {
 		case "live":
-			controlModuleHelper(data.Run, &setup.ModulesStatus.Live, data.Module,
+			controlModuleHelper(data.Run, &setup.InternalModuleState.Live, data.Module,
 				live.Live, chans[0], wg)
 			break
 		case "target":
-			controlModuleHelper(data.Run, &setup.ModulesStatus.Target, data.Module,
+			controlModuleHelper(data.Run, &setup.InternalModuleState.Target, data.Module,
 				target.Target, chans[1], wg)
 		case "disk":
-			controlModuleHelper(data.Run, &setup.ModulesStatus.Disk, data.Module,
+			controlModuleHelper(data.Run, &setup.InternalModuleState.Disk, data.Module,
 				disk.Disk, chans[2], wg)
 		case "ram":
-			controlModuleHelper(data.Run, &setup.ModulesStatus.RAM, data.Module,
+			controlModuleHelper(data.Run, &setup.InternalModuleState.RAM, data.Module,
 				ram.RAM, chans[3], wg)
 		case "cpu":
-			controlModuleHelper(data.Run, &setup.ModulesStatus.CPU, data.Module,
+			controlModuleHelper(data.Run, &setup.InternalModuleState.CPU, data.Module,
 				cpu.CPU, chans[4], wg)
 		}
 	}
@@ -115,27 +115,27 @@ func controlModuleHelper(run bool, moduleStatus *bool, moduleName string,
 }
 
 func runModules(chans [5]chan bool, wg *sync.WaitGroup) {
-	if setup.ModulesStatus.Live {
+	if setup.InternalModuleState.Live {
 		wg.Add(1)
 		utils.ModuleLogs(setup.MainLogFile, "Started live module")
 		go live.Live(chans[0], wg)
 	}
-	if setup.ModulesStatus.Target {
+	if setup.InternalModuleState.Target {
 		wg.Add(1)
 		utils.ModuleLogs(setup.MainLogFile, "Started target module")
 		go target.Target(chans[1], wg)
 	}
-	if setup.ModulesStatus.Disk {
+	if setup.InternalModuleState.Disk {
 		wg.Add(1)
 		utils.ModuleLogs(setup.MainLogFile, "Started disk module")
 		go disk.Disk(chans[2], wg)
 	}
-	if setup.ModulesStatus.RAM {
+	if setup.InternalModuleState.RAM {
 		wg.Add(1)
 		utils.ModuleLogs(setup.MainLogFile, "Started ram module")
 		go ram.RAM(chans[3], wg)
 	}
-	if setup.ModulesStatus.CPU {
+	if setup.InternalModuleState.CPU {
 		wg.Add(1)
 		utils.ModuleLogs(setup.MainLogFile, "Started cpu module")
 		go cpu.CPU(chans[4], wg)

--- a/live/db.go
+++ b/live/db.go
@@ -12,7 +12,7 @@ import (
 func LoadConfig() *Config {
 	var conf = new(Config)
 	err := setup.Database.QueryRow("SELECT * FROM Live WHERE profile=?",
-		setup.ModulesStatus.Profile).Scan(&conf.Profile, &conf.HeadURL,
+		setup.UserModuleState.Profile).Scan(&conf.Profile, &conf.HeadURL,
 		&conf.RecheckThreshold, &conf.PingThreshold, &conf.HeadThreshold,
 		&conf.PingAddress, &conf.PingProtocol)
 	if err != nil {

--- a/live/run.go
+++ b/live/run.go
@@ -130,6 +130,6 @@ func GetConfJSON() []byte {
 func Init() {
 	conf = LoadConfig()
 	if conf == nil {
-		utils.CheckConf(logFile, setup.MainLogFile, "live", &setup.ModulesStatus.Profile, setup.Live)
+		utils.CheckConf(logFile, setup.MainLogFile, "live", &setup.UserModuleState.Profile, setup.Live)
 	}
 }

--- a/ram/db.go
+++ b/ram/db.go
@@ -12,7 +12,7 @@ import (
 func LoadConfig() *Config {
 	var conf = new(Config)
 	err := setup.Database.QueryRow("SELECT * FROM Ram WHERE profile=?",
-		setup.ModulesStatus.Profile).Scan(&conf.Profile, &conf.RAMWarningLimit,
+		setup.UserModuleState.Profile).Scan(&conf.Profile, &conf.RAMWarningLimit,
 		&conf.RecheckThreshold)
 	if err != nil {
 		utils.ModuleError(logFile, "Error while quering from databse", err.Error())

--- a/ram/run.go
+++ b/ram/run.go
@@ -42,6 +42,7 @@ func RAM(status <-chan bool, wg *sync.WaitGroup) {
 
 	utils.ModuleLogs(logFile, "Running with "+conf.Profile+" profile")
 	conf.InitMemoryConst(&ramInfo.Consts)
+	ramInfo.Status.Normal = true
 	checkRAM()
 	for {
 		select {
@@ -94,6 +95,6 @@ func GetStatusJSON() []byte {
 func Init() {
 	conf = LoadConfig()
 	if conf == nil {
-		utils.CheckConf(logFile, setup.MainLogFile, "ram", &setup.ModulesStatus.Profile, setup.RAM)
+		utils.CheckConf(logFile, setup.MainLogFile, "ram", &setup.UserModuleState.Profile, setup.RAM)
 	}
 }

--- a/setup/setupModule.go
+++ b/setup/setupModule.go
@@ -10,16 +10,19 @@ import (
 	"github.com/BurntSushi/toml"
 )
 
+type ModulesStatus struct {
+	Profile string
+	Live    bool
+	Target  bool
+	Disk    bool
+	RAM     bool
+	CPU     bool
+}
+
 var (
 	//ModulesStatus holds the running status of all the modules of monitor
-	ModulesStatus struct {
-		Profile string
-		Live    bool
-		Target  bool
-		Disk    bool
-		RAM     bool
-		CPU     bool
-	}
+	UserModuleState     = ModulesStatus{}
+	InternalModuleState = ModulesStatus{}
 )
 
 func loadStatus() {
@@ -28,24 +31,24 @@ func loadStatus() {
 		initStatus()
 		return
 	}
-	_, err := toml.DecodeFile(ConfigVars.ModuleInfoFilePath, &ModulesStatus) // Read the module status file
+	_, err := toml.DecodeFile(ConfigVars.ModuleInfoFilePath, &UserModuleState) // Read the module status file
 	if err != nil {
 		utils.ModuleError(MainLogFile, "The module status file is corrupt, creating one with default values", err.Error())
 		initStatus()
-	} else if ModulesStatus.Profile == "" { //TODO add check to ensure profile exists in db
+	} else if UserModuleState.Profile == "" { //TODO add check to ensure profile exists in db
 		utils.ModuleError(MainLogFile, "The module status file does not contain profile or profile does not exists", "Creating one with default values")
 		initStatus()
 	}
+	InternalModuleState = UserModuleState
 }
 
 func initStatus() {
-	ModulesStatus.Profile = "default"
-	ModulesStatus.Live = true
-	ModulesStatus.Target = true
-	ModulesStatus.Disk = true
-	ModulesStatus.RAM = true
-	ModulesStatus.CPU = true
-
+	UserModuleState.Profile = "default"
+	UserModuleState.Live = true
+	UserModuleState.Target = true
+	UserModuleState.Disk = true
+	UserModuleState.RAM = true
+	UserModuleState.CPU = true
 	SaveStatus()
 }
 
@@ -53,7 +56,7 @@ func initStatus() {
 func SaveStatus() {
 	var buffer bytes.Buffer
 	encoder := toml.NewEncoder(&buffer)
-	err := encoder.Encode(ModulesStatus)
+	err := encoder.Encode(UserModuleState)
 	log.SetOutput(MainLogFile)
 	if err != nil {
 		log.Fatal(err)

--- a/target/db.go
+++ b/target/db.go
@@ -12,7 +12,7 @@ import (
 func LoadConfig() *Config {
 	var conf = new(Config)
 	err := setup.Database.QueryRow("SELECT * FROM Target WHERE profile=?",
-		setup.ModulesStatus.Profile).Scan(&conf.Profile, &conf.FuzzyThreshold,
+		setup.UserModuleState.Profile).Scan(&conf.Profile, &conf.FuzzyThreshold,
 		&conf.RecheckThreshold)
 	if err != nil {
 		utils.ModuleError(logFile, "Error while quering from databse", err.Error())


### PR DESCRIPTION
This is required when monitor is restarted it will start with modules running which were set by the users.
